### PR TITLE
Change default timeout from 5000 to 5 seconds

### DIFF
--- a/lib/usps/configuration.rb
+++ b/lib/usps/configuration.rb
@@ -6,7 +6,7 @@ module USPS
   #            (only specific requests are supported).
   class Configuration < Struct.new(:username, :timeout, :testing)
     def initialize
-      self.timeout  = 5000
+      self.timeout  = 5
       self.testing  = false
       self.username = ENV['USPS_USER']
     end


### PR DESCRIPTION
Typhoeus timeout is in seconds (https://github.com/typhoeus/typhoeus#timeouts), so 5000 is almost the same as no timeout.
