### PR TITLE
Drop typhoeus dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,9 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :development do
+group :development, :test do
   gem 'rake'
   gem 'rspec'
   gem 'rspec-core'
+  gem 'webmock'
 end

--- a/lib/usps/client.rb
+++ b/lib/usps/client.rb
@@ -41,8 +41,10 @@ module USPS
 
     def get(uri)
       http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = uri.scheme == 'https'
+      http.open_timeout = USPS.config.timeout
       http.read_timeout = USPS.config.timeout
+      http.ssl_timeout = USPS.config.timeout
+      http.use_ssl = uri.scheme == 'https'
       http.request_get(uri.request_uri).body
     end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe USPS::Client do
+  it 'sends request and processes response' do
+    zip = 90210
+
+    stub_request(:get, "http://production.shippingapis.com/ShippingAPI.dll?API=CityStateLookup&XML=%3CCityStateLookupRequest%20USERID=%22TESTING%22%3E%3CZipCode%20ID=%220%22%3E%3CZip5%3E90210%3C/Zip5%3E%3C/ZipCode%3E%3C/CityStateLookupRequest%3E").
+      to_return(status: 200, body: load_data('city_and_state_lookup_1.xml'))
+
+    client = USPS::Client.new
+    request = USPS::Request::CityAndStateLookup.new(zip)
+    response = client.request(request)
+    expect(response.get(zip).city).to eq 'BEVERLY HILLS'
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ Bundler.require(:default, :development)
 require 'usps'
 USPS.username = 'TESTING'
 
+require 'webmock/rspec'
+
 def load_data(path)
   (@_file_cache ||= {})[path] ||= File.read(File.expand_path("../data/#{path}", __FILE__))
 end

--- a/usps.gemspec
+++ b/usps.gemspec
@@ -14,6 +14,4 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("builder",  ">= 2.1.2")
   s.add_runtime_dependency("nokogiri", ">= 1.4.1")
-  s.add_runtime_dependency("typhoeus", ">= 0.1.18")
 end
-


### PR DESCRIPTION
Typhoeus is big dependency for a very small task. It also had some thread safety concerns. I suggest using native `Net::HTTP`.
