### PR TITLE
Update API certification servers and test values; always use secure endpoints 

### DIFF
--- a/lib/usps/client.rb
+++ b/lib/usps/client.rb
@@ -38,15 +38,10 @@ module USPS
     end
 
     private
-    def server(request)
-      dll = testing? ? "ShippingAPITest.dll" : "ShippingAPI.dll"
 
-      case
-      when request.secure?
-        "https://secure.shippingapis.com/#{dll}"
-      else
-        "http://production.shippingapis.com/#{dll}"
-      end
+    def server(_request)
+      dll = testing? ? "ShippingAPITest.dll" : "ShippingAPI.dll"
+      "https://production.shippingapis.com/#{dll}"
     end
   end
 end

--- a/lib/usps/client.rb
+++ b/lib/usps/client.rb
@@ -44,8 +44,6 @@ module USPS
       case
       when request.secure?
         "https://secure.shippingapis.com/#{dll}"
-      when testing?
-        "http://testing.shippingapis.com/#{dll}"
       else
         "http://production.shippingapis.com/#{dll}"
       end

--- a/lib/usps/request/address_standardization.rb
+++ b/lib/usps/request/address_standardization.rb
@@ -4,7 +4,6 @@ module USPS::Request
     config(
       :api => 'Verify',
       :tag => 'AddressValidateRequest',
-      :secure => false,
       :response => USPS::Response::AddressStandardization
     )
 

--- a/lib/usps/request/base.rb
+++ b/lib/usps/request/base.rb
@@ -1,29 +1,21 @@
 module USPS::Request
   class Base
     class << self
-      attr_reader :api, :tag, :secure, :response
-
-      alias :secure? :secure
+      attr_reader :api, :tag, :response
 
       # Config given
       #   api: The USPS API name as given in the request URL
       #   tag: The root tag used for the request
-      #   secure: Whether or not the request is against the secure server
       #   response: The USPS::Response class used to handle responses
       def config(options = {})
         @api = options[:api].to_s
         @tag = options[:tag].to_s
-        @secure = !!options[:secure]
         @response = options[:response]
       end
     end
 
     def send!
       USPS.client.request(self)
-    end
-
-    def secure?
-      !!self.class.secure?
     end
 
     def api

--- a/lib/usps/request/city_and_state_lookup.rb
+++ b/lib/usps/request/city_and_state_lookup.rb
@@ -4,7 +4,6 @@ module USPS::Request
     config(
       :api => 'CityStateLookup',
       :tag => 'CityStateLookupRequest',
-      :secure => false,
       :response => USPS::Response::CityAndStateLookup
     )
 

--- a/lib/usps/request/delivery_confirmation.rb
+++ b/lib/usps/request/delivery_confirmation.rb
@@ -3,7 +3,6 @@ module USPS::Request
     config(
       :api => 'DeliveryConfirmationV3',
       :tag => 'DeliveryConfirmationV3.0Request',
-      :secure => true,
       :response => USPS::Response::DeliveryConfirmation
     )
 

--- a/lib/usps/request/delivery_confirmation_certify.rb
+++ b/lib/usps/request/delivery_confirmation_certify.rb
@@ -3,7 +3,6 @@ module USPS::Request
     config(
       :api => 'DelivConfirmCertifyV3',
       :tag => 'DelivConfirmCertifyV3.0Request',
-      :secure => true,
       :response => USPS::Response::DeliveryConfirmation
     )
   end

--- a/lib/usps/request/tracking_field_lookup.rb
+++ b/lib/usps/request/tracking_field_lookup.rb
@@ -8,7 +8,6 @@ module USPS::Request
     config(
       :api => 'TrackV2',
       :tag => 'TrackFieldRequest',
-      :secure => false,
       :response => USPS::Response::TrackingFieldLookup
     )
 

--- a/lib/usps/request/tracking_lookup.rb
+++ b/lib/usps/request/tracking_lookup.rb
@@ -8,7 +8,6 @@ module USPS::Request
     config(
       :api => 'TrackV2',
       :tag => 'TrackRequest',
-      :secure => false,
       :response => USPS::Response::TrackingLookup
     )
 

--- a/lib/usps/request/zip_code_lookup.rb
+++ b/lib/usps/request/zip_code_lookup.rb
@@ -7,7 +7,6 @@ module USPS::Request
     config(
       :api => 'ZipCodeLookup',
       :tag => 'ZipCodeLookupRequest',
-      :secure => false,
       :response => USPS::Response::AddressStandardization
     )
 

--- a/lib/usps/test/address_verification.rb
+++ b/lib/usps/test/address_verification.rb
@@ -11,7 +11,7 @@ class USPS::Test
       assert_equal 'GREENBELT', address.city
       assert_equal 'MD', address.state
       assert_equal '20770', address.zip5
-      assert_equal '1440', address.zip4
+      assert_equal '1435', address.zip4
     end
 
     def test_address_standardization_2

--- a/lib/usps/test/zip_code_lookup.rb
+++ b/lib/usps/test/zip_code_lookup.rb
@@ -14,7 +14,7 @@ class USPS::Test
       assert_equal 'GREENBELT', address.city
       assert_equal 'MD', address.state
       assert_equal '20770', address.zip5
-      assert_equal '1440', address.zip4
+      assert_equal '1435', address.zip4
     end
 
     def test_zip_code_lookup_2

--- a/spec/request/address_standardization_spec.rb
+++ b/spec/request/address_standardization_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe USPS::Request::AddressStandardization do
   it "should be using the proper USPS api settings" do
     USPS::Request::AddressStandardization.tap do |klass|
-      expect(klass.secure).to be_falsey
       expect(klass.api).to eq('Verify')
       expect(klass.tag).to eq('AddressValidateRequest')
     end
@@ -14,7 +13,7 @@ describe USPS::Request::AddressStandardization do
       USPS::Request::AddressStandardization.new([USPS::Address.new] * 6)
     end.to raise_exception(ArgumentError)
   end
-    
+
   it "should be able to build a proper request" do
     request = USPS::Request::AddressStandardization.new(
       USPS::Address.new(

--- a/spec/request/city_and_state_lookup_spec.rb
+++ b/spec/request/city_and_state_lookup_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe USPS::Request::CityAndStateLookup do
   it "should be using the proper USPS api settings" do
     USPS::Request::CityAndStateLookup.tap do |klass|
-      expect(klass.secure).to be_falsey
       expect(klass.api).to eq('CityStateLookup')
       expect(klass.tag).to eq('CityStateLookupRequest')
     end

--- a/spec/request/delivery_confirmation_certify_spec.rb
+++ b/spec/request/delivery_confirmation_certify_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe USPS::Request::DeliveryConfirmationCertify do
   it 'should be using the proper USPS api settings' do
     USPS::Request::DeliveryConfirmationCertify.tap do |klass|
-      expect(klass.secure).to be_truthy
       expect(klass.api).to eq('DelivConfirmCertifyV3')
       expect(klass.tag).to eq('DelivConfirmCertifyV3.0Request')
     end

--- a/spec/request/delivery_confirmation_spec.rb
+++ b/spec/request/delivery_confirmation_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe USPS::Request::DeliveryConfirmation do
   it 'should be using the proper USPS api settings' do
     USPS::Request::DeliveryConfirmation.tap do |klass|
-      expect(klass.secure).to be_truthy
       expect(klass.api).to eq('DeliveryConfirmationV3')
       expect(klass.tag).to eq('DeliveryConfirmationV3.0Request')
     end

--- a/spec/request/tracking_field_spec.rb
+++ b/spec/request/tracking_field_spec.rb
@@ -4,7 +4,6 @@ describe USPS::Request::TrackingFieldLookup do
 
   it 'should be using the proper USPS api settings' do
     USPS::Request::TrackingFieldLookup.tap do |klass|
-      expect(klass.secure).to be_falsey
       expect(klass.api).to eq('TrackV2')
       expect(klass.tag).to eq('TrackFieldRequest')
     end

--- a/spec/request/tracking_spec.rb
+++ b/spec/request/tracking_spec.rb
@@ -4,7 +4,6 @@ describe USPS::Request::TrackingLookup do
 
   it 'should be using the proper USPS api settings' do
     USPS::Request::TrackingLookup.tap do |klass|
-      expect(klass.secure).to be_falsey
       expect(klass.api).to eq('TrackV2')
       expect(klass.tag).to eq('TrackRequest')
     end

--- a/spec/request/zip_code_lookup_spec.rb
+++ b/spec/request/zip_code_lookup_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe USPS::Request::ZipCodeLookup do
   it "should be using the proper USPS api settings" do
     USPS::Request::ZipCodeLookup.tap do |klass|
-      expect(klass.secure).to be_falsey
       expect(klass.api).to eq('ZipCodeLookup')
       expect(klass.tag).to eq('ZipCodeLookupRequest')
     end


### PR DESCRIPTION
_I saw the gem is no longer maintained, but hopefully this helps someone move forward._

USPS has updated its servers. This has all APIs working except for Tracking, which seems like it no longer has a working test API: `USPS_USER=XXXXX bundle exec rake certify`

- Updates some certification values (fixes some issues described in #16)