### PR TITLE
Empty response body raises an error

### DIFF
--- a/lib/usps/client.rb
+++ b/lib/usps/client.rb
@@ -19,6 +19,18 @@ module USPS
         raise TimeoutError
       end
 
+      # If there are services that are down or there is no network connection available then
+      # the request may not time out but instead return a blank body and a response_code of 0.
+      #
+      # The Typhoeus return_code might be :couldnt_connect or :couldnt_resolve_host rather than
+      # :operation_timedout.
+      #
+      # In any case a response_code of 0 is exceptional so we raise an exception.
+      #
+      if response.response_code == 0
+        raise ConnectionError
+      end
+
       # Parse the request
       xml = Nokogiri::XML.parse(response.body)
 

--- a/lib/usps/errors.rb
+++ b/lib/usps/errors.rb
@@ -3,8 +3,9 @@ module USPS
   #
   # StandardError
   #   USPS::Error
-  #     USPS::TimeoutError
-  #     USPS::AuthorizationError
+  #     USPS::ConnectionError
+  #       USPS::TimeoutError
+  #       USPS::AuthorizationError
   #     USPS::ValidationError
   #       USPS::InvalidCityError
   #       USPS::InvalidStateError
@@ -38,8 +39,9 @@ module USPS
     end
   end
 
-  class TimeoutError < Error; end
-  class AuthorizationError < Error; end
+  class ConnectionError < Error; end
+  class TimeoutError < ConnectionError; end
+  class AuthorizationError < ConnectionError; end
 
   class ValidationError < Error; end
   class InvalidCityError < ValidationError; end

--- a/spec/lib/usps/client_spec.rb
+++ b/spec/lib/usps/client_spec.rb
@@ -5,17 +5,31 @@ describe USPS::Client do
     config(:api => 'testing', :tag => 'TestingTag')
   end
 
-  context "when a request times out" do
-    let(:typhoeus_mock) { instance_double(Typhoeus::Response, timed_out?: true) }
+  let(:typhoeus_mock) { instance_double(Typhoeus::Response, timed_out?: timed_out, response_code: response_code) }
+  let(:timed_out) { false }
+  let(:response_code) { 200 }
 
-    before do
-      allow(Typhoeus::Request).to receive(:get).and_return(typhoeus_mock)
-    end
+  before do
+    allow(Typhoeus::Request).to receive(:get).and_return(typhoeus_mock)
+  end
+
+  context "when a request times out" do
+    let(:timed_out) { true }
 
     it "raises a TimeoutError" do
       expect {
         USPS::Client.new.request(RequestSubclassForTesting.new).send!
       }.to raise_error USPS::TimeoutError
+    end
+  end
+
+  context "when response_code = 0" do
+    let(:response_code) { 0 }
+
+    it "raises a ConnectionError" do
+      expect {
+        USPS::Client.new.request(RequestSubclassForTesting.new).send!
+      }.to raise_error USPS::ConnectionError
     end
   end
 end


### PR DESCRIPTION
Hi there, I hope I did everything requested. I tried to follow the directions in the Readme as best I could. 

When testing on my development machine I noticed that if you disable your network connection then the first request will timeout. Subsequent requests however are not attempted and thus are not a timeout but do return a blank body. 

I'm not sure whether the fault lies with Typhoes or libcurl itself as they're difficult to tease apart. 

Either way, I thought that if we get a blank body I this should be considered an exceptional case and hence the PR. 

@gaffneyc as commented in the code it is up to you whether you think this should be a different type of error. I figured for consumers of this gem, like us, this type of error might either fall into the `TimeoutError` case or an `AddressNotFound` case. I picked `TimeoutError` as I thought it was more correct. I could also see you considering this a different type of error altogether 🤷 